### PR TITLE
corrected typo in get_cluster_version

### DIFF
--- a/openshift-install-wrapper
+++ b/openshift-install-wrapper
@@ -356,7 +356,7 @@ get_cluster_version() {
   if [[ ! -z ${INSTALLOPTS[version]} ]]; then
     verbose "Version already defined with --version parameter to ${INSTALLOPTS[version]}. Skipping version detection..."
     return
-  done
+  fi
 
   out "→ Finding version in cluster directory..."
   verbose "  Directory: ${clusterdir}"


### PR DESCRIPTION
There was a typo error in the get_cluster_version function