### PR TITLE
Feature/baseurl

### DIFF
--- a/config.env
+++ b/config.env
@@ -1,3 +1,3 @@
 NAME=OpenShift Install Wrapper
-VERSION=1.2.3
+VERSION=1.3.0
 TARGETDIR=~/.local/ocp4

--- a/openshift-install-wrapper
+++ b/openshift-install-wrapper
@@ -138,7 +138,8 @@ Options:
   --customize <actions>          - customize the cluster with some post-install actions
   --list                         - lists all existing clusters
   --list-csv                     - lists all existing clusters in CSV format
-  --baseurl                      - sets the baseurl to download the binaries
+  --dev-preview                  - allows to install any released dev-preview version
+  --baseurl                      - sets the baseurl to download the binaries (overrides the use of --dev-preview)
                                    default: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp
   --verbose                      - shows more information during the execution
   --quiet                        - quiet mode (no output at all)
@@ -507,6 +508,7 @@ main() {
       --list-csv)    ACTION=list; LISTFORMAT="csv";;
       --verbose)     VERBOSE=1;;
       --quiet)       QUIET=1;;
+      --dev-preview) shift; __baseurl=${baseurl/\/ocp/\/ocp-dev-preview};;
       --baseurl)     shift; __baseurl="${1}";;
       --help|-h)     usage >&2; safe_exit;;
       --azure-resource-group) shift; INSTALLOPTS[azure-resource-group]="${1}";;

--- a/openshift-install-wrapper
+++ b/openshift-install-wrapper
@@ -21,7 +21,7 @@ __clustersdir=${__basedir}/clusters
 __baseurl=https://mirror.openshift.com/pub/openshift-v4/clients/ocp
 
 # defaults
-VERSION=1.2.3
+VERSION=1.3.0
 VERBOSE=0
 QUIET=0
 FORCE=0

--- a/openshift-install-wrapper
+++ b/openshift-install-wrapper
@@ -138,7 +138,8 @@ Options:
   --customize <actions>          - customize the cluster with some post-install actions
   --list                         - lists all existing clusters
   --list-csv                     - lists all existing clusters in CSV format
-
+  --baseurl                      - sets the baseurl to download the binaries
+                                   default: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp
   --verbose                      - shows more information during the execution
   --quiet                        - quiet mode (no output at all)
   --help|-h                      - shows this message
@@ -506,6 +507,7 @@ main() {
       --list-csv)    ACTION=list; LISTFORMAT="csv";;
       --verbose)     VERBOSE=1;;
       --quiet)       QUIET=1;;
+      --baseurl)     shift; __baseurl="${1}";;
       --help|-h)     usage >&2; safe_exit;;
       --azure-resource-group) shift; INSTALLOPTS[azure-resource-group]="${1}";;
       --vsphere-vcenter)     shift; INSTALLOPTS[vsphere-vcenter]="${1}";;


### PR DESCRIPTION
Allow fine grained control about where the binaries are downloaded:

- `--dev-preview` parameter modifies the baseurl so new versions can be found
- `--baseurl` parameter allows total control over the url 