### PR TITLE
include check for htpasswd presence

### DIFF
--- a/scripts/add-htpasswd-idp
+++ b/scripts/add-htpasswd-idp
@@ -7,6 +7,13 @@
 # Mandatory function
 # start main - do not remove this line and do not change the function name
 main() {
+  # check if htpasswd is available
+  if ! command -v htpasswd &> /dev/null
+  then
+    err "htpasswd is required to run add-htpasswd-idp"
+    exit
+  fi
+
   # parse parameters from ${1}, if any
   if [[ ${1} == *"="* ]]; then
     success "Using custom users from command line parameters."


### PR DESCRIPTION
Include a small check for htpasswd (prevents headaches on minimal bastion hosts).