### PR TITLE
changed detect version to better work with release candidate

### DIFF
--- a/openshift-install-wrapper
+++ b/openshift-install-wrapper
@@ -502,7 +502,7 @@ get_cluster_version() {
 
   out "→ Finding version in cluster directory..."
   verbose "  Directory: ${clusterdir}"
-  INSTALLOPTS[version]=$(grep -Po '(?<=OpenShift Installer )[v0-9.]*' ${clusterdir}/.openshift_install.log 2>/dev/null| head -n 1 | tr -d v)
+  INSTALLOPTS[version]=$(grep '="OpenShift Installer ' ${clusterdir}/.openshift_install.log 2>/dev/null |head -1 |tr -d '"'|awk '{ print $(NF) }')
   success "Version detected: ${INSTALLOPTS[version]}."
 
   [[ -z ${INSTALLOPTS[version]} ]] && die "Error: Can't find the installer version in the directory ${clusterdir}. Aborting." || true


### PR DESCRIPTION
This pull request is needed to make the version detect work when a release candidate is installed.

Anyway, the use of '--version' option is an existing workaround.
